### PR TITLE
Update the joke teller to take more generalised query

### DIFF
--- a/electRon.aiml
+++ b/electRon.aiml
@@ -1740,29 +1740,8 @@
     <template><srai>* faculty</srai></template>
 </category>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <category>
-<pattern>TELL ME A JOKE</pattern>
+<pattern>* Tell me a joke</pattern>
 
 <template><random>
 <li>I met a Dutch girl with inflatable shoes last week, phoned her up to arrange a date but unfortunately she'd popped her clogs.  </li>
@@ -1912,6 +1891,24 @@
 
 </random></template>
 </category>
+
+
+
+<category>
+    <pattern>* Tell me a joke *</pattern>
+    <template><srai>* Tell me a joke</srai></template>
+</category>
+
+<category>
+    <pattern>Tell me a joke *</pattern>
+    <template><srai>* Tell me a joke</srai></template>
+</category>
+
+<category>
+    <pattern>Tell me a joke</pattern>
+    <template><srai>* Tell me a joke</srai></template>
+</category>
+
 
 
 </aiml>


### PR DESCRIPTION
Hey Shrish

I noticed that the 'Tell a Joke' functionality had no generalised query intake templates. I've updated it match the more general input query to the jokeTeller
Please review and merge.

Thanks
Naman